### PR TITLE
Another batch of improvements

### DIFF
--- a/HumbleBundle.pl
+++ b/HumbleBundle.pl
@@ -110,10 +110,8 @@ for my $key (@keys) {
     say 'Working on bundle: ' . $items{$key}{name} . ' (key ' . $key . ')';
 
     for my $book ( @{$items{$key}{books}} ) {
-
         my @downloads = @{$book->{downloads}};
         if ( @downloads ) {
-
             my $filename = NameCleanUp( $book->{human_name} );
 
             say "  Working on $filename -";
@@ -136,6 +134,7 @@ for my $key (@keys) {
                     if ( $fullFilename =~ /(480|720|1080)p$/ ) {
                         $fullFilename = $fullFilename . ".mp4";
                     }
+                    $fullFilename =~ s/\.pdf \((.+)\)$/.$1.pdf/;
                     my $save = "$dir/$fullFilename";
 
                     if ( -e $save ) {
@@ -212,17 +211,19 @@ if ($nSkipped > 0) {
 sub NameCleanUp {
     my ($name) = @_;
 
-    ( my $cleanName = $name ) =~ s/\s+/_/g; # Could make space replacement optional
+    ( my $cleanName = $name ) =~ s/^\s+|\s+$//g; # Trim the string
 
-    $cleanName =~ s/\/|\)|:|,|_\|\|/_-/g;
-    $cleanName =~ s/\(/-_/g;
-    $cleanName =~ s/\N{U+2018}|\N{U+2019}|\N{U+201A}/'/g;
-    $cleanName =~ s/\N{U+201C}|\N{U+201D}|\N{U+201F}/"/g;
-    $cleanName =~ s/\.|!|//g;
-    $cleanName =~ s/'//g; # Could make quote removal optional
-    $cleanName =~ s/&/and/g;
-    $cleanName =~ s/#/Num_/g;
-    $cleanName =~ s/_-$//;
+    $cleanName =~ s/\/|\(|\)|:|,| \|\|/ - /g; # Replace slash, paren, colon, comma, and pipe-pipe with a dash
+    $cleanName =~ s/\N{U+2018}|\N{U+2019}|\N{U+201A}/'/g; # Replace Unicode single-quote with '
+    $cleanName =~ s/\N{U+201C}|\N{U+201D}|\N{U+201F}/"/g; # Replace Unicode double-quote with "
+    $cleanName =~ s/\.|!//g;    # Eliminate period and exclamation point
+    $cleanName =~ s/&/ and /g;  # Replace ampersand with the word "and"
+    $cleanName =~ s/#/ Num /g;  # Replace number sign with the word "Num"
+    $cleanName =~ s/\s*-\s*$//; # Remove a trailing dash
+    $cleanName =~ s/\s\s+/ /g;  # Collapse consecutive whitespace
+
+    $cleanName =~ s/'//g;       # remove single quotes (comment out to prevent)
+    $cleanName =~ s/ /_/g;      # replace space with underscore (comment out to prevent)
 
     return $cleanName;
 }

--- a/README.md
+++ b/README.md
@@ -23,4 +23,4 @@ Contributions very much welcome.
 * Make the script portable between OS types? Not important to me exactly, but I'm sure someone else would like it
 * Handle huge file sizes and make maximum file size configurable
 * Make it possible to download only certain file types, or to skip certain file types
-* Optionally skip errors, keeping track and reporting failures at the end
+* Maybe make the save directory if it does not exist

--- a/list-HumbleBundle.pl
+++ b/list-HumbleBundle.pl
@@ -94,6 +94,7 @@ foreach my $key (sort { $items{$a}->{created} cmp $items{$b}->{created} } (keys 
                         if ( $fullFilename =~ /(480|720|1080)p$/ ) {
                             $fullFilename = $fullFilename . ".mp4";
                         }
+                        $fullFilename =~ s/\.pdf \((.+)\)$/.$1.pdf/;
                     }
                     my $save = "$dir/$fullFilename";
 
@@ -107,17 +108,19 @@ foreach my $key (sort { $items{$a}->{created} cmp $items{$b}->{created} } (keys 
 sub NameCleanUp {
     my ($name) = @_;
 
-    ( my $cleanName = $name ) =~ s/\s+/_/g; # Could make space replacement optional
+    ( my $cleanName = $name ) =~ s/^\s+|\s+$//g; # Trim the string
 
-    $cleanName =~ s/\/|\)|:|,|_\|\|/_-/g;
-    $cleanName =~ s/\(/-_/g;
-    $cleanName =~ s/\N{U+2018}|\N{U+2019}|\N{U+201A}/'/g;
-    $cleanName =~ s/\N{U+201C}|\N{U+201D}|\N{U+201F}/"/g;
-    $cleanName =~ s/\.|!|//g;
-    $cleanName =~ s/'//g; # Could make quote removal optional
-    $cleanName =~ s/&/and/g;
-    $cleanName =~ s/#/Num_/g;
-    $cleanName =~ s/_-$//;
+    $cleanName =~ s/\/|\(|\)|:|,| \|\|/ - /g; # Replace slash, paren, colon, comma, and pipe-pipe with a dash
+    $cleanName =~ s/\N{U+2018}|\N{U+2019}|\N{U+201A}/'/g; # Replace Unicode single-quote with '
+    $cleanName =~ s/\N{U+201C}|\N{U+201D}|\N{U+201F}/"/g; # Replace Unicode double-quote with "
+    $cleanName =~ s/\.|!//g;    # Eliminate period and exclamation point
+    $cleanName =~ s/&/ and /g;  # Replace ampersand with the word "and"
+    $cleanName =~ s/#/ Num /g;  # Replace number sign with the word "Num"
+    $cleanName =~ s/\s*-\s*$//; # Remove a trailing dash
+    $cleanName =~ s/\s\s+/ /g;  # Collapse consecutive whitespace
+
+    $cleanName =~ s/'//g;       # remove single quotes (comment out to prevent)
+    $cleanName =~ s/ /_/g;      # replace space with underscore (comment out to prevent)
 
     return $cleanName;
 }


### PR DESCRIPTION
Improvements included in this batch of changes:

- Fix names like ".pdf (hq)" to be ".hq.pdf"
- trim filenames (some have an extra space at the end)
- reorganize name cleanup to make space removal easily optional
- Keep track of errors and report them at the end, but keep trying other files
- Move extension mangling to a subroutine
- Move MD5 checking to a subroutine and also check filesize (much faster)
- For filename cleaning, simplify the check for sequences to replace with a dash
- Handle "read me" files that don't have a download URL and need to be skipped
- Improve listing output with some small tweaks
