### PR TITLE
fix typo for config file name

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 HumbleBundle is a great way to support charities and get some cool books/games in the process. My only issue is that there isn't a native way to bulk-download the files in the bundle. Initially I was using a javascript snippet that would generate a list of wget commands but then the site changed, invalidating the code. After poking around some I found that a couple of simple API calls would give me everything I needed to get the files, thus this script was born. It's still very rough but it's coming along as I take the time to work on it.
 
-Right now, the perl script expects a file `.humblebundle.cfg` to be found in the current directory.  This file should look like this:
+Right now, the perl script expects a file `.humbleBundle.cfg` to be found in the current directory.  This file should look like this:
 
 ```
 saveDir: '/path/to/save/folder'
@@ -19,7 +19,7 @@ The save directory must exist before running the script.
 Contributions very much welcome.
 
 ## TODO
-* Ask to set a download path, save in the .humblebundle.cfg file
+* Ask to set a download path, save in the .humbleBundle.cfg file
 * Get the sessionID cookie via an API call instead of logging in via a browser and logging in manually
 * Put more work in to cleaning up the file names, maybe make it optional for those that don't care about spaces/etc in the filenames
 * Ask if the directory name created is fine, let the user edit it


### PR DESCRIPTION
it is .humbleBundle.cfg instead of .humblebundle.cfg. Otherwise i get the error: `Config file, .humbleBundle.cfg, missing!`

